### PR TITLE
feat: presentation

### DIFF
--- a/src/main/kotlin/kr/argonaut/argonaut/presentation/server/ServerCommandLineRunner.kt
+++ b/src/main/kotlin/kr/argonaut/argonaut/presentation/server/ServerCommandLineRunner.kt
@@ -1,0 +1,17 @@
+package kr.argonaut.argonaut.presentation.server
+
+import kotlinx.coroutines.runBlocking
+import kr.argonaut.argonaut.domain.server.ServerManager
+import org.springframework.boot.CommandLineRunner
+import org.springframework.stereotype.Component
+
+@Component
+class ServerCommandLineRunner(
+    private val serverManager: ServerManager
+): CommandLineRunner {
+    override fun run(vararg args: String?) {
+        runBlocking {
+            serverManager.run(force = false, withLog = true)
+        }
+    }
+}

--- a/src/main/kotlin/kr/argonaut/argonaut/presentation/server/ServerController.kt
+++ b/src/main/kotlin/kr/argonaut/argonaut/presentation/server/ServerController.kt
@@ -1,0 +1,27 @@
+package kr.argonaut.argonaut.presentation.server
+
+import kotlinx.coroutines.*
+import kr.argonaut.argonaut.application.application.ApplicationService
+import kr.argonaut.argonaut.application.server.ServerService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ServerController(
+    private val serverService: ServerService,
+    private val applicationService: ApplicationService,
+) {
+    @PostMapping("/reboot")
+    fun reboot() {
+        CoroutineScope(Dispatchers.Default).launch {
+            serverService.reboot()
+        }
+    }
+    @PostMapping("/shutdown")
+    fun shutdown() {
+        CoroutineScope(Dispatchers.Default).launch {
+            delay(100)
+            applicationService.shutdown()
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- presentation 레이어를 구성하였습니다.
- 이제 어플리케이션을 시작 할 때 자동으로 manifest를 기반으로 minecraft server를 실행시킵니다.
- 또한 HTTP API를 통해 서버와 어플리케이션을 종료하거나, 서버를 재시작할 수 있습니다.