### PR TITLE
feat: server manifest by environment

### DIFF
--- a/src/main/kotlin/kr/argonaut/argonaut/infra/manifest/ApplicationCachedServerManifestLoader.kt
+++ b/src/main/kotlin/kr/argonaut/argonaut/infra/manifest/ApplicationCachedServerManifestLoader.kt
@@ -15,3 +15,6 @@ class ApplicationCachedServerManifestLoader(
         return manifest
     }
 }
+
+fun <T: ServerManifestLoader> T.withApplicationCached(): ServerManifestLoader =
+    ApplicationCachedServerManifestLoader(this)

--- a/src/main/kotlin/kr/argonaut/argonaut/infra/manifest/EnvironmentServerManifestLoader.kt
+++ b/src/main/kotlin/kr/argonaut/argonaut/infra/manifest/EnvironmentServerManifestLoader.kt
@@ -1,0 +1,36 @@
+package kr.argonaut.argonaut.infra.manifest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kr.argonaut.argonaut.domain.manifest.Environment
+import kr.argonaut.argonaut.domain.manifest.ServerManifest
+import kr.argonaut.argonaut.domain.manifest.ServerManifestLoader
+import kr.argonaut.argonaut.infra.manifest.data.GithubServerManifest
+import java.net.URL
+
+class EnvironmentServerManifestLoader(
+    private val objectMapper: ObjectMapper,
+): ServerManifestLoader {
+    override suspend fun load(env: Environment): ServerManifest {
+        require(env != Environment.PRODUCTION) {
+            "Production server can't use EnvironmentServerManifestLoader."
+        }
+
+        return withContext(Dispatchers.IO) {
+            val url = getManifestUrlByEnvironment()
+            val content = url.readText(charset = Charsets.UTF_8)
+
+            return@withContext toManifest(content)
+        }
+    }
+
+    private fun getManifestUrlByEnvironment(): URL =
+        System.getenv("SERVER_MANIFEST_URL").let(::URL)
+
+    private fun toManifest(response: String): ServerManifest =
+        objectMapper.readValue(
+            response,
+            GithubServerManifest::class.java,
+        ).toManifest()
+}

--- a/src/main/kotlin/kr/argonaut/argonaut/infra/manifest/FallbackServerManifestLoader.kt
+++ b/src/main/kotlin/kr/argonaut/argonaut/infra/manifest/FallbackServerManifestLoader.kt
@@ -1,0 +1,38 @@
+package kr.argonaut.argonaut.infra.manifest
+
+import kr.argonaut.argonaut.domain.manifest.Environment
+import kr.argonaut.argonaut.domain.manifest.ServerManifest
+import kr.argonaut.argonaut.domain.manifest.ServerManifestLoader
+import kr.argonaut.argonaut.lib.getLogger
+import org.slf4j.Logger
+
+class FallbackServerManifestLoader(
+    val loader: ServerManifestLoader,
+    val fallback: ServerManifestLoader,
+    logger: Logger? = null,
+): ServerManifestLoader {
+    val logger = logger ?: getLogger()
+    private val loaderName = loader::class.simpleName
+    private val fallbackName = fallback::class.simpleName
+
+    override suspend fun load(env: Environment): ServerManifest {
+        try {
+            logger.info("Attempting load server manifest via $loaderName.")
+            return loader.load(env)
+        } catch (e: Throwable) {
+            logger.warn(
+                "Failed to load server manifest via $loaderName." +
+                " Attempting load via fallback strategy ($fallbackName).",
+                e
+            )
+            return fallback.load(env)
+        }
+    }
+}
+
+fun <T: ServerManifestLoader> T.withFallback(
+    fallback: ServerManifestLoader,
+): ServerManifestLoader = FallbackServerManifestLoader(
+    loader = this,
+    fallback = fallback
+)

--- a/src/main/kotlin/kr/argonaut/argonaut/infra/manifest/ServerManifestLoaderConfiguration.kt
+++ b/src/main/kotlin/kr/argonaut/argonaut/infra/manifest/ServerManifestLoaderConfiguration.kt
@@ -1,5 +1,6 @@
 package kr.argonaut.argonaut.infra.manifest
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import kr.argonaut.argonaut.domain.manifest.ServerManifestLoader
 import kr.argonaut.argonaut.infra.github.GithubService
 import org.springframework.context.annotation.Bean
@@ -8,8 +9,11 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class ServerManifestLoaderConfiguration {
     @Bean
-    fun serverManifestLoader(githubService: GithubService): ServerManifestLoader =
-        ApplicationCachedServerManifestLoader(
-            GithubServerManifestLoader(githubService)
-        )
+    fun serverManifestLoader(
+        objectMapper: ObjectMapper,
+        githubService: GithubService,
+    ): ServerManifestLoader =
+        EnvironmentServerManifestLoader(objectMapper)
+            .withFallback(GithubServerManifestLoader(githubService))
+            .withApplicationCached()
 }


### PR DESCRIPTION
### Summary
- local환경에서 테스트 수행시, dev/production과는 다른 Server manifest를 통해 argonaut server가 실행되어야할 때가 있습니다.
- 이러한 상황을 지원하기 위해 Server manifest를 환경변수를 통해 설정할 수 있도록 수정하였습니다.
- 이제 Server manifest의 URI를 환경변수에 등록하여 로컬에서 별도의 Server manifest를 사용할 수 있습니다.

### Example

**env**
```env
SERVER_MANIFEST_URL=file:///Users/argonaut-mc/argonaut/workspace/manifest.json
```

**/Users/argonaut-mc/argonaut/workspace/manifest.json**
```json
{
  "spigotVersion": "1.20.4",
  "pluginConfigs": [
    {
      "name": "PluginMetrics"
    },
    {
      "name": "SuperiorSkyblock2"
    }
  ],
  "pluginJars": [
    {
      "groupId": "com.bgsoftware",
      "artifactId": "superiorskyblock",
      "version": "2023.3.b168"
    }
  ]
}
```